### PR TITLE
更新 ColorOS 14 兼容信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@
 
 为了使该模块模板更加适合您的手机，需要对模块模板内的配置文件进行调整：
 
-- **OPPO/一加 ColorOS：** 将 `/system/etc/fonts.xml` 复制到 `/system/system_ext/etc/` *（若无该文件夹请先创建）* 目录并重命名为 `fonts_base.xml`。
+- **OPPO/一加 ColorOS 13 及以下版本：** 将 `/system/etc/fonts.xml` 复制到 `/system/system_ext/etc/` *（若无该文件夹请先创建）* 目录并重命名为 `fonts_base.xml`。
+- **OPPO/一加 ColorOS 14 版本：** 将 `/system/etc/fonts.xml` 复制两份到 `/system/system_ext/etc/` *（若无该文件夹请先创建）* 目录并重命名为 `fonts_base.xml` 及 `fonts_ule.xml`。
 - **一加 HydrogenOS 11 及以上版本：** 将 `/system/etc/fonts.xml` 复制到相同文件夹，并重命名为 `fonts_base.xml。`
 - **魅族 Flyme：** 将 `/system/etc/fonts.xml` 复制 3 份到相同文件夹，并重命名为以下 3 个文件： `fonts_flyme.xml`、`fonts_inter.xml` 和 `fonts_slate.xml`。
 - **小米 MIUI 12.5：** 需刷入 [空字体模块 v4.4](https://yukonga.lanzoub.com/iSxAP07pu05i) / [v4.1](https://wwi.lanzoui.com/iEDyZt6a83g)。


### PR DESCRIPTION
ColorOS 14 增加了一个文件，已在 OnePlus 12 上测试过修改后的文件。

关闭模块后的截图，可见新版本系统增加了一个文件：

![图片](https://github.com/lxgw/advanced-cjk-font-magisk-module-template/assets/14086980/73d91271-ebca-44f4-913b-25a377672974)

![图片](https://github.com/lxgw/advanced-cjk-font-magisk-module-template/assets/14086980/e408dc2d-f685-4ae4-9824-0d43e270bd6f)
